### PR TITLE
Optimize styling of car data display

### DIFF
--- a/src/components/CarStat.tsx
+++ b/src/components/CarStat.tsx
@@ -4,7 +4,7 @@
  * */
 
 import {RefObject, useEffect, useState} from "react";
-import CarDataFetcher from "../services/CarDataFetcher.ts";
+import TimePartitionedLoader from "../services/TimePartitionedLoader.ts";
 import CarData from "../interfaces/CarData.ts";
 import styled from "styled-components";
 
@@ -64,7 +64,7 @@ export default function CarStat({timeRef, driverNumber}: {
     timeRef: RefObject<HTMLDivElement | null>,
     driverNumber: number
 }) {
-    const [fetcher, setFetcher] = useState<CarDataFetcher<CarData> | null>(null);
+    const [fetcher, setFetcher] = useState<TimePartitionedLoader<CarData> | null>(null);
     const carData = getCarData(timeRef.current?.textContent);
 
     function getCarData(displayTime: string | null | undefined): CarData {
@@ -98,7 +98,7 @@ export default function CarStat({timeRef, driverNumber}: {
     }
 
     useEffect(() => {
-        setFetcher(new CarDataFetcher("car_data_" + driverNumber));
+        setFetcher(new TimePartitionedLoader("car_data_" + driverNumber));
     }, [driverNumber]);
 
     return (

--- a/src/components/CarStat.tsx
+++ b/src/components/CarStat.tsx
@@ -18,6 +18,8 @@ const Container = styled.div`
     background: #e0e0e0;
     color: #1e1e2f;
     border-radius: 8px;
+    box-sizing: border-box;
+    margin: 1mm;
 `;
 
 const StatCard = styled.div`
@@ -35,7 +37,7 @@ const Label = styled.div`
 `;
 
 const Value = styled.div`
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     font-weight: bold;
 `;
 
@@ -53,7 +55,15 @@ const Bar = styled.div<{ ratio: number }>`
     background: #60c;
 `;
 
-export default function CarStat({timeRef, driverNumber}: { timeRef: RefObject<HTMLDivElement | null>, driverNumber: number }) {
+const BarStatWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+export default function CarStat({timeRef, driverNumber}: {
+    timeRef: RefObject<HTMLDivElement | null>,
+    driverNumber: number
+}) {
     const [fetcher, setFetcher] = useState<CarDataFetcher<CarData> | null>(null);
     const carData = getCarData(timeRef.current?.textContent);
 
@@ -94,8 +104,7 @@ export default function CarStat({timeRef, driverNumber}: { timeRef: RefObject<HT
     return (
         <Container>
             <StatCard>
-                <Label>Driver #</Label>
-                <Value>{carData.driver_number}</Value>
+                <Label>Driver #{carData.driver_number}</Label>
             </StatCard>
             <StatCard>
                 <Label>Speed (km/h)</Label>
@@ -105,18 +114,20 @@ export default function CarStat({timeRef, driverNumber}: { timeRef: RefObject<HT
                 <Label>RPM</Label>
                 <Value>{carData.rpm.toLocaleString()}</Value>
             </StatCard>
-            <StatCard>
-                <Label>Throttle</Label>
-                <BarContainer>
-                    <Bar ratio={carData.throttle}/>
-                </BarContainer>
-            </StatCard>
-            <StatCard>
-                <Label>Brake</Label>
-                <BarContainer>
-                    <Bar ratio={carData.brake}/>
-                </BarContainer>
-            </StatCard>
+            <BarStatWrapper>
+                <StatCard style={{padding: "2mm", width: "50%", marginRight: "1mm"}}>
+                    <Label>Throttle</Label>
+                    <BarContainer>
+                        <Bar ratio={carData.throttle}/>
+                    </BarContainer>
+                </StatCard>
+                <StatCard style={{padding: "2mm", width: "50%", marginLeft: "1mm"}}>
+                    <Label>Brake</Label>
+                    <BarContainer>
+                        <Bar ratio={carData.brake}/>
+                    </BarContainer>
+                </StatCard>
+            </BarStatWrapper>
             <StatCard>
                 <Label>DRS</Label>
                 <Value>{carData.drs ? "ON" : "OFF"}</Value>

--- a/src/components/CarStatBar.tsx
+++ b/src/components/CarStatBar.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import CarStat from "./CarStat.tsx";
+import {RefObject} from "react";
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+/**
+ * Wrapper containing two CarStat components, created for styling
+ * @author Xingyu Zhou
+ * */
+export default function CarStatBar({timeRef}: {timeRef: RefObject<HTMLDivElement | null>}) {
+    return (
+        <Wrapper>
+            <CarStat timeRef={timeRef} driverNumber={1}/>
+            <CarStat timeRef={timeRef} driverNumber={2}/>
+        </Wrapper>
+    )
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import useCanvasAnimation from "./RaceAnimationHook";
 import { useParams } from "react-router-dom";
-import CarStat from "./CarStat.tsx";
+import CarStatBar from "./CarStatBar.tsx";
 
 const DashboardWrapper = styled.div`
   display: flex;
@@ -149,8 +149,7 @@ export default function Dashboard() {
             </TimeDisplay>
           </ProgressWrapper>
         </MapWrapper>
-        <CarStat timeRef={currentTimeDisplayRef} driverNumber={1}></CarStat>
-        <CarStat timeRef={currentTimeDisplayRef} driverNumber={2}></CarStat>
+        <CarStatBar timeRef={currentTimeDisplayRef}/>
       </DashboardWrapper>
     </>
   );

--- a/src/interfaces/DateAvailable.ts
+++ b/src/interfaces/DateAvailable.ts
@@ -1,5 +1,5 @@
 /**
- * Represents a data with a date property, used for {@link CarDataFetcher}
+ * Represents a data with a date property, used for {@link TimePartitionedLoader}
  * @author Xingyu Zhou
  * */
 export default interface DateAvailable {

--- a/src/services/TimePartitionedLoader.ts
+++ b/src/services/TimePartitionedLoader.ts
@@ -10,6 +10,17 @@ interface IndexEntry {
     end: string
 }
 
+/**
+ * <p>A loader util for loading arrays of data from the web server that are partitioned by time.</p>
+ * <p>
+ * To use it, you need a directory of partitioned files,
+ * each file should contain an array of objects that implement {@link DateAvailable}.
+ * Then, create a file called index.json that contains an array of {@link IndexEntry},
+ * which tells the loader the time range of each file.
+ * </p>
+ * <p>Example: /public/car_data_1/index.json</p>
+ * @author Xingyu Zhou
+ * */
 export default class TimePartitionedLoader<T extends DateAvailable> {
     private readonly url: string;
     private index: Array<IndexEntry> | undefined;

--- a/src/services/TimePartitionedLoader.ts
+++ b/src/services/TimePartitionedLoader.ts
@@ -10,7 +10,7 @@ interface IndexEntry {
     end: string
 }
 
-export default class CarDataFetcher<T extends DateAvailable> {
+export default class TimePartitionedLoader<T extends DateAvailable> {
     private readonly url: string;
     private index: Array<IndexEntry> | undefined;
     private cache: Map<string, T[]> = new Map<string, T[]>();


### PR DESCRIPTION
1. shrink the width of car stat display to avoid oversizing of other components
2. optimize naming and docs for TimePartitionedLoader (CarDataFetcher)